### PR TITLE
Make 'fwupdmgr get-updates' call think it's "interactive"

### DIFF
--- a/0001-qubes-make-fwupdmgr-get-updates-think-it-s-interacti.patch
+++ b/0001-qubes-make-fwupdmgr-get-updates-think-it-s-interacti.patch
@@ -1,0 +1,68 @@
+From 653abf10b5c31cdce1a270b19f5508080766378c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Fri, 23 Jun 2023 03:25:28 +0200
+Subject: [PATCH] qubes: make 'fwupdmgr get-updates' think it's interactive
+
+When stdout of fwupdmgr is redirected to a pipe, it assumes it's running
+non-interactive. This makes it not call
+fwupd_client_set_feature_flags(), which results in some (or all) updates not
+being listed.
+
+"Fix" this by using new pty for stdout capture, instead of a pipe.
+---
+ contrib/qubes/src/qubes_fwupdmgr.py | 29 ++++++++++++++++++++++++-----
+ 1 file changed, 24 insertions(+), 5 deletions(-)
+
+diff --git a/contrib/qubes/src/qubes_fwupdmgr.py b/contrib/qubes/src/qubes_fwupdmgr.py
+index 031caf251..ee73af2f4 100755
+--- a/contrib/qubes/src/qubes_fwupdmgr.py
++++ b/contrib/qubes/src/qubes_fwupdmgr.py
+@@ -7,8 +7,10 @@
+ # SPDX-License-Identifier: LGPL-2.1+
+ #
+ 
++import errno
+ import json
+ import os
++import pty
+ import re
+ import shutil
+ import subprocess
+@@ -366,11 +368,28 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
+         ):
+             raise ValueError(f"{version} < {self.dmi_version} Downgrade not allowed")
+ 
+-    def _get_dom0_devices(self):
+-        """Gathers information about devices connected in dom0."""
+-        cmd_get_dom0_devices = [FWUPDMGR, "--json", "get-devices"]
+-        p = subprocess.Popen(cmd_get_dom0_devices, stdout=subprocess.PIPE)
+-        self.dom0_devices_info = p.communicate()[0].decode()
++    def _get_dom0_updates(self):
++        """Gathers information about available updates."""
++        cmd_get_dom0_updates = [FWUPDMGR, "--json", "get-updates"]
++        # connect stdout to a pty, otherwise get-updates works in
++        # non-interactive mode and doesn't list all the updates
++        # (based on FWUUPD_FEATURE_* flags)
++        mstdout, sstdout = pty.openpty()
++        p = subprocess.Popen(cmd_get_dom0_updates, stdout=sstdout)
++        os.close(sstdout)
++        data = b""
++        while True:
++            try:
++                new_data = os.read(mstdout, 4096)
++            except OSError as e:
++                if e.errno == errno.EIO:
++                    # process exited
++                    break
++            if not new_data:
++                break
++            data += new_data
++        self.dom0_updates_info = data.decode()
++        p.wait()
+         if p.returncode != 0:
+             raise Exception("fwupd-qubes: Getting devices info failed")
+ 
+-- 
+2.39.2
+

--- a/fwupd.spec.in
+++ b/fwupd.spec.in
@@ -8,6 +8,7 @@ Source0:   fwupd-%{version}.tar.xz
 Source1:   meson.build
 Patch1:    0001-contrib-change-symlink-to-be-relative.patch
 Patch2:    0001-qubes-fix-vendor-check-and-make-it-optional.patch
+Patch3:    0001-qubes-make-fwupdmgr-get-updates-think-it-s-interacti.patch
 BuildArch: noarch
 
 BuildRequires: meson


### PR DESCRIPTION
Otherwise it doesn't list updates that might require interaction (during the actual update, not listing). See patch description for more details.