### PR TITLE
Fix several issues blocking basic usage or tests

### DIFF
--- a/0006-Only-support-JCat-for-verification-of-metadata-and-f.patch
+++ b/0006-Only-support-JCat-for-verification-of-metadata-and-f.patch
@@ -1,0 +1,36 @@
+From 76010d681a73a9f82e5e37b8246537ff0e2b2a10 Mon Sep 17 00:00:00 2001
+From: Richard Hughes <richard@hughsie.com>
+Date: Wed, 28 Aug 2024 23:36:04 +0100
+Subject: [PATCH 06/10] Only support JCat for verification of metadata and
+ firmware
+
+This means we can adopt different checksums and signatures (PQ?) in the future
+without making fwupd changes.
+
+(cherry picked from commit 80d5f98eef9cc91724a4fbbcdab237cae4d1a722,
+changes to contrib/qubes/ only)
+---
+ contrib/qubes/src/qubes_fwupdmgr.py | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/contrib/qubes/src/qubes_fwupdmgr.py b/contrib/qubes/src/qubes_fwupdmgr.py
+index 8fce44e63..646aa1a47 100755
+--- a/contrib/qubes/src/qubes_fwupdmgr.py
++++ b/contrib/qubes/src/qubes_fwupdmgr.py
+@@ -119,13 +119,6 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
+             # actually needing refreshing
+             if remote.get("Kind") != "download":
+                 continue
+-            # skip unsupported keyring kind
+-            if remote.get("KeyringKind") not in ("jcat",):
+-                print(
+-                    "Skipping remote '{}' due to unsupported keyring type '{}'".format(
+-                        name, remote.get("KeyringKind")
+-                    )
+-                )
+             assert "MetadataUri" in remote
+             remotes[name] = remote["MetadataUri"]
+ 
+-- 
+2.52.0
+

--- a/0007-qubes-don-t-fail-on-duplicate-filenames-in-jcat-file.patch
+++ b/0007-qubes-don-t-fail-on-duplicate-filenames-in-jcat-file.patch
@@ -1,0 +1,36 @@
+From 04bd01e5a690b6879bc67375ab19f1d83e78113c Mon Sep 17 00:00:00 2001
+From: Matt McCutchen <matt@mattmccutchen.net>
+Date: Mon, 12 Jan 2026 11:25:56 -0500
+Subject: [PATCH 07/10] qubes: don't fail on duplicate filenames in jcat file
+
+---
+ contrib/qubes/src/vms/fwupd_download_updates.py | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/contrib/qubes/src/vms/fwupd_download_updates.py b/contrib/qubes/src/vms/fwupd_download_updates.py
+index 48eedd65a..da6735175 100644
+--- a/contrib/qubes/src/vms/fwupd_download_updates.py
++++ b/contrib/qubes/src/vms/fwupd_download_updates.py
+@@ -85,10 +85,19 @@ class DownloadData(FwupdVmCommon):
+             raise Exception("fwupd-qubes: Extracting jcat file failed")
+         # rename extracted files to match jcat base name, instead of "ID"
+         # inside jcat
++        #
++        # As of 2025-10-11, the jcat file contains two p7b files of the same
++        # name, and `jcat-tool export` arbitrarily keeps one of them. dom0
++        # currently doesn't use these files, but we need to avoid crashing here
++        # by trying to rename the same file twice.
++        paths_already_done = set()
+         for line in stdout.decode("ascii").splitlines():
+             if not line.startswith("Wrote "):
+                 continue
+             path = line.split(" ", 1)[1]
++            if path in paths_already_done:
++                continue
++            paths_already_done.add(path)
+             base_path, ext = os.path.splitext(path)
+             if base_path == self.metadata_file:
+                 continue
+-- 
+2.52.0
+

--- a/0008-qubes-treat-remote-Enabled-field-as-a-JSON-boolean.patch
+++ b/0008-qubes-treat-remote-Enabled-field-as-a-JSON-boolean.patch
@@ -1,0 +1,27 @@
+From a2608cc6917c471ee27debd262907e3477366855 Mon Sep 17 00:00:00 2001
+From: Matt McCutchen <matt@mattmccutchen.net>
+Date: Mon, 12 Jan 2026 11:28:18 -0500
+Subject: [PATCH 08/10] qubes: treat remote `Enabled` field as a JSON boolean
+
+This updates the Qubes OS code to match
+eee24b164255d655a8586569a682024d83266e98.
+---
+ contrib/qubes/src/qubes_fwupdmgr.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/contrib/qubes/src/qubes_fwupdmgr.py b/contrib/qubes/src/qubes_fwupdmgr.py
+index 646aa1a47..f876d0a12 100755
+--- a/contrib/qubes/src/qubes_fwupdmgr.py
++++ b/contrib/qubes/src/qubes_fwupdmgr.py
+@@ -113,7 +113,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
+         for remote in remotes_list:
+             name = remote["Id"]
+             # skip disabled
+-            if remote.get("Enabled", "true") != "true":
++            if not remote.get("Enabled", True):
+                 continue
+             # skip local - for metadata refresh, we only care about those
+             # actually needing refreshing
+-- 
+2.52.0
+

--- a/0009-qubes-use-Locations-0-field-of-update-instead-of-Uri.patch
+++ b/0009-qubes-use-Locations-0-field-of-update-instead-of-Uri.patch
@@ -1,0 +1,216 @@
+From db35488a6a240ae1766e3868c06700f83c3a0ed5 Mon Sep 17 00:00:00 2001
+From: Matt McCutchen <matt@mattmccutchen.net>
+Date: Mon, 26 Jan 2026 16:50:40 -0500
+Subject: [PATCH 09/10] qubes: use `Locations[0]` field of update instead of
+ `Uri`
+
+This updates the Qubes OS code to cope with
+51cf6674435ece2febab15e8fe645d77eea70056.
+
+Also update the test data to have `Locations` and not `Uri`.
+---
+ contrib/qubes/src/qubes_fwupdmgr.py |  4 +--
+ contrib/qubes/test/fwupd_logs.py    | 53 ++++++++++++++++++++---------
+ 2 files changed, 38 insertions(+), 19 deletions(-)
+
+diff --git a/contrib/qubes/src/qubes_fwupdmgr.py b/contrib/qubes/src/qubes_fwupdmgr.py
+index f876d0a12..6ffe01012 100755
+--- a/contrib/qubes/src/qubes_fwupdmgr.py
++++ b/contrib/qubes/src/qubes_fwupdmgr.py
+@@ -214,7 +214,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
+                 "Releases": [
+                     {
+                         "Version": update["Version"],
+-                        "Url": update["Uri"],
++                        "Url": update["Locations"][0],
+                         "Checksum": update["Checksum"][-1],
+                         "Description": update["Description"],
+                     }
+@@ -379,7 +379,7 @@ class QubesFwupdmgr(FwupdHeads, FwupdUpdate, FwupdReceiveUpdates):
+                             {
+                                 "Version": downgrade["Version"],
+                                 "Description": downgrade["Description"],
+-                                "Url": downgrade["Uri"],
++                                "Url": downgrade["Locations"][0],
+                                 "Checksum": downgrade["Checksum"][-1],
+                             }
+                             for downgrade in device["Releases"]
+diff --git a/contrib/qubes/test/fwupd_logs.py b/contrib/qubes/test/fwupd_logs.py
+index 8a87a5ac3..ceb935292 100644
+--- a/contrib/qubes/test/fwupd_logs.py
++++ b/contrib/qubes/test/fwupd_logs.py
+@@ -57,7 +57,6 @@ UPDATE_INFO = """{
+                                "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
+                                "ipfs://QmUByRuHG9Gb2s8gKKVqDcjhUrn8vy62B4WqjbpWDD42cf"
+                            ],
+-                           "Uri" : "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
+                            "Homepage" : "http://www.hughski.com/",
+                            "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                            "Vendor" : "Hughski Limited",
+@@ -156,7 +155,6 @@ GET_DEVICES = """{
+             "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
+             "ipfs://QmUByRuHG9Gb2s8gKKVqDcjhUrn8vy62B4WqjbpWDD42cf"
+           ],
+-          "Uri" : "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
+           "Homepage" : "http://www.hughski.com/",
+           "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+           "Vendor" : "Hughski Limited",
+@@ -184,7 +182,6 @@ GET_DEVICES = """{
+             "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab",
+             "ipfs://QmdWFrYo1YJxgGU37Qy7LkwPQM26vPMVxLRANUga6TzSjW"
+           ],
+-          "Uri" : "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab",
+           "Homepage" : "http://www.hughski.com/",
+           "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+           "Vendor" : "Hughski Limited",
+@@ -209,7 +206,6 @@ GET_DEVICES = """{
+             "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab",
+             "ipfs://QmQ648kwvv52wuqPoKjm5zLGXngQnmuJzp1xtJmTEbzgz5"
+           ],
+-          "Uri" : "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab",
+           "Homepage" : "http://www.hughski.com/",
+           "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+           "Vendor" : "Hughski Limited",
+@@ -237,7 +233,6 @@ GET_DEVICES = """{
+             "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab",
+             "ipfs://QmZ1DKKsWZQuvnff2DJTDJESMaXTpsc5zfNGX7Sb2HibAn"
+           ],
+-          "Uri" : "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab",
+           "Homepage" : "http://www.hughski.com/",
+           "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+           "Vendor" : "Hughski Limited",
+@@ -340,7 +335,9 @@ GET_DEVICES_NO_UPDATES = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1482901200,
+-                    "Uri" : "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -360,7 +357,9 @@ GET_DEVICES_NO_UPDATES = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1450792062,
+-                    "Uri" : "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -383,7 +382,9 @@ GET_DEVICES_NO_UPDATES = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1444059405,
+-                    "Uri" : "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -406,7 +407,9 @@ GET_DEVICES_NO_UPDATES = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 15680,
+                     "Created" : 1416675439,
+-                    "Uri" : "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -530,7 +533,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1482901200,
+-                    "Uri" : "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -549,7 +554,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1450792062,
+-                    "Uri" : "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -572,7 +579,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1444059405,
+-                    "Uri" : "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -595,7 +604,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 15680,
+                     "Created" : 1416675439,
+-                    "Uri" : "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -649,7 +660,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1482901200,
+-                    "Uri" : "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/0a29848de74d26348bc5a6e24fc9f03778eddf0e-hughski-colorhug2-2.0.7.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -669,7 +682,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1450792062,
+-                    "Uri" : "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/170f2c19f17b7819644d3fcc7617621cc3350a04-hughski-colorhug2-2.0.6.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -692,7 +707,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 16384,
+                     "Created" : 1444059405,
+-                    "Uri" : "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/f7dd4ab29fa610438571b8b62b26b0b0e57bb35b-hughski-colorhug2-2.0.5.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+@@ -715,7 +732,9 @@ GET_DEVICES_NO_VERSION = """{
+                     "License" : "GPL-2.0+",
+                     "Size" : 15680,
+                     "Created" : 1416675439,
+-                    "Uri" : "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab",
++                    "Locations" : [
++                        "https://fwupd.org/downloads/30a121f26c039745aeb5585252d4a9b5386d71cb-hughski-colorhug2-2.0.2.cab"
++                    ],
+                     "Homepage" : "http://www.hughski.com/",
+                     "SourceUrl" : "https://github.com/hughski/colorhug2-firmware",
+                     "Vendor" : "Hughski Limited",
+-- 
+2.52.0
+

--- a/0010-qubes-tests-fix-metadata-signature-timestamp-skew.patch
+++ b/0010-qubes-tests-fix-metadata-signature-timestamp-skew.patch
@@ -1,0 +1,123 @@
+From e83127c4c793e75262d9b9c597092a97f3343fdc Mon Sep 17 00:00:00 2001
+From: Matt McCutchen <matt@mattmccutchen.net>
+Date: Tue, 27 Jan 2026 12:45:06 -0500
+Subject: [PATCH 10/10] qubes tests: fix metadata signature timestamp skew
+
+fwupdmgr refuses to refresh metadata if the new metadata has an older
+signature timestamp than the existing metadata. Fix two ways this could
+happen in the tests:
+
+- A normal refresh uses firmware.xml.zst as specified by the lvfs
+  remote, but test_refresh_metadata_dom0 used firmware.xml.xz. Change it
+  to use the URL from the lvfs remote (which is what we'd rather be
+  testing anyway).
+
+- test_refresh_metadata_dom0_custom used a custom metadata file and
+  assumed it was older than the default firmware.xml.zst, which is no
+  longer a valid assumption. Instead, bypass the timestamp check by
+  deleting fwupd's copy of the metadata before and after the test.
+---
+ contrib/qubes/src/qubes_fwupdmgr.py       |  7 ++++
+ contrib/qubes/test/test_qubes_fwupdmgr.py | 43 ++++++++++++++++++-----
+ 2 files changed, 41 insertions(+), 9 deletions(-)
+
+diff --git a/contrib/qubes/src/qubes_fwupdmgr.py b/contrib/qubes/src/qubes_fwupdmgr.py
+index 6ffe01012..3c88afd13 100755
+--- a/contrib/qubes/src/qubes_fwupdmgr.py
++++ b/contrib/qubes/src/qubes_fwupdmgr.py
+@@ -43,6 +43,13 @@ FWUPD_DOM0_DIR = "/var/cache/fwupd/qubes"
+ FWUPD_DOM0_METADATA_DIR = os.path.join(FWUPD_DOM0_DIR, "metadata")
+ FWUPD_DOM0_UPDATES_DIR = os.path.join(FWUPD_DOM0_DIR, "updates")
+ FWUPD_DOWNLOAD_PREFIX = "https://fwupd.org/downloads/"
++# Warning: As of 2026-01-27, the lvfs remote has switched to using
++# firmware.xml.zst, and `qubes-fwupdmgr refresh` honors that configuration by
++# default. If any code tried to use these URLs to refresh the main fwupd
++# metadata, it would be liable to run into errors due to skew between the
++# signature timestamps of the xz and zst files. Currently, these URLs appear to
++# be used only by the Heads code, which doesn't support the zst format, so they
++# can't be changed at the moment.
+ METADATA_URL = "https://fwupd.org/downloads/firmware.xml.xz"
+ METADATA_URL_JCAT = "https://fwupd.org/downloads/firmware.xml.xz.jcat"
+ 
+diff --git a/contrib/qubes/test/test_qubes_fwupdmgr.py b/contrib/qubes/test/test_qubes_fwupdmgr.py
+index cc20d38d2..ffbe9205b 100755
+--- a/contrib/qubes/test/test_qubes_fwupdmgr.py
++++ b/contrib/qubes/test/test_qubes_fwupdmgr.py
+@@ -33,6 +33,7 @@ elif os.path.exists(QUBES_FWUPDMGR_BINDIR):
+ qfwupd = importlib.util.module_from_spec(qfwupd_spec)
+ qfwupd_spec.loader.exec_module(qfwupd)
+ 
++FWUPD_METADATA_LVFS_DIR = "/var/lib/fwupd/metadata/lvfs"
+ FWUPD_DOM0_DIR = "/var/cache/fwupd/qubes"
+ FWUPD_DOM0_UPDATES_DIR = os.path.join(FWUPD_DOM0_DIR, "updates")
+ FWUPD_DOM0_UNTRUSTED_DIR = os.path.join(FWUPD_DOM0_UPDATES_DIR, "untrusted")
+@@ -67,6 +68,11 @@ def check_whonix_updatevm():
+     return p.returncode == 0
+ 
+ 
++def clear_lvfs_metadata():
++    for fname in os.listdir(FWUPD_METADATA_LVFS_DIR):
++        os.unlink(os.path.join(FWUPD_METADATA_LVFS_DIR, fname))
++
++
+ class TestQubesFwupdmgr(unittest.TestCase):
+     def setUp(self):
+         self.q = qfwupd.QubesFwupdmgr()
+@@ -122,7 +128,7 @@ class TestQubesFwupdmgr(unittest.TestCase):
+ 
+     @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+     def test_refresh_metadata_dom0(self):
+-        self.q.refresh_metadata(metadata_url=qfwupd.METADATA_URL)
++        self.q.refresh_metadata(remote_name="lvfs")
+         self.assertEqual(
+             self.captured_output.getvalue().strip(),
+             "Successfully refreshed metadata manually",
+@@ -130,18 +136,37 @@ class TestQubesFwupdmgr(unittest.TestCase):
+         )
+ 
+     @unittest.skipUnless("qubes" in platform.release(), "Requires Qubes OS")
+-    @unittest.expectedFailure  # fwupd refuses metadata downgrade
+     def test_refresh_metadata_dom0_custom(self):
+-        self.q.refresh_metadata(metadata_url=CUSTOM_METADATA)
+-        self.assertEqual(
+-            self.captured_output.getvalue().strip(),
+-            "Successfully refreshed metadata manually",
+-            msg="Metadata refresh failed.",
+-        )
++        # fwupd does not allow a refresh if the new metadata has an older
++        # signature timestamp than the existing metadata, and it's best not to
++        # make any assumption about the relative signature timestamps of the
++        # custom and default metadata. (Apparently, in the past, the default
++        # metadata had a newer signature timestamp, but as of 2026-01-26, the
++        # custom metadata has a newer signature timestamp. The timestamp that
++        # appears to matter is the one inside the gpg signature, not the one in
++        # the jcat wrapper.) The only way we found to bypass the downgrade check
++        # was to delete the existing metadata. Do that once at the beginning so
++        # this test can work and again at the end so everything that uses the
++        # default metadata can work. If this test gets interrupted before the
++        # `finally` can run, then qubes-fwupdmgr will be broken on your system
++        # until you clear the metadata manually; sorry.
++        clear_lvfs_metadata()
++        try:
++            self.q.refresh_metadata(
++                remote_name="lvfs",
++                metadata_url=CUSTOM_METADATA
++            )
++            self.assertEqual(
++                self.captured_output.getvalue().strip(),
++                "Successfully refreshed metadata manually",
++                msg="Metadata refresh failed.",
++            )
++        finally:
++            clear_lvfs_metadata()
+ 
+     @unittest.skipUnless(check_whonix_updatevm(), "Requires sys-whonix")
+     def test_refresh_metadata_whonix(self):
+-        self.q.refresh_metadata(whonix=True, metadata_url=qfwupd.METADATA_URL)
++        self.q.refresh_metadata(whonix=True, remote_name="lvfs")
+         self.assertEqual(
+             self.captured_output.getvalue().strip(),
+             "Successfully refreshed metadata manually",
+-- 
+2.52.0
+

--- a/fwupd.spec.in
+++ b/fwupd.spec.in
@@ -11,6 +11,11 @@ Patch2: 0002-qubes-make-fwupdmgr-get-updates-think-it-s-interacti.patch
 Patch3: 0003-qubes-Drop-custom-vendor-and-version-check.patch
 Patch4: 0004-qubes-do-not-use-deprecated-imp-module-in-tests.patch
 Patch5: 0005-qubes-fix-checking-for-whonix-in-tests.patch
+Patch6: 0006-Only-support-JCat-for-verification-of-metadata-and-f.patch
+Patch7: 0007-qubes-don-t-fail-on-duplicate-filenames-in-jcat-file.patch
+Patch8: 0008-qubes-treat-remote-Enabled-field-as-a-JSON-boolean.patch
+Patch9: 0009-qubes-use-Locations-0-field-of-update-instead-of-Uri.patch
+Patch10: 0010-qubes-tests-fix-metadata-signature-timestamp-skew.patch
 BuildArch: noarch
 
 BuildRequires: meson


### PR DESCRIPTION
- Duplicate filenames in the jcat file (QubesOS/qubes-issues#10315)
- Issues specific to the newer fwupd in Qubes 4.3 (QubesOS/qubes-issues#10544):
  - Remote `Enabled` field is now a boolean
  - Remote `KeyringKind` field is gone
  - Firmware release `Uri` field is gone
- Test failures related to metadata signature timestamp skew (xz versus zst file, custom metadata)

---
I'm just a user of qubes-fwupdmgr and no expert on how to maintain it, but I thought I would try to help get it working again at least for Qubes 4.3 users without them having to apply a bunch of workarounds from issue threads.

For easier review, here's a [comparison link](https://github.com/mattmccutchen/fwupd/compare/qubes-fixes-20260112.base...qubes-fixes-20260112) for a series of commits corresponding to the patches added in this PR.  Running `git format-patch --start-number 6 qubes-fixes-20260112.base..qubes-fixes-20260112` in that repository should reproduce the patches in this PR.

**Testing:** I built the dom0 and VM packages and installed them on my system (Qubes 4.3, UpdateVM is Fedora 43) and ran `cd /usr/share/qubes-fwupd && python3 -m unittest -v test.test_qubes_fwupdmgr`, and the tests passed except for 6 that were skipped with "Required device not connected" or "Requires sys-whonix".  Also, in a manual test, `qubes-fwupdmgr refresh && qubes-fwupdmgr update` succeeds with "No updates available".  I haven't yet had a chance to perform an actual firmware update with the latest version of this code, but I've performed several updates successfully using the draft patches attached to QubesOS/qubes-issues#10315 and QubesOS/qubes-issues#10544.

_Update:_ I'm getting an intermittent failure in `test_refresh_metadata_dom0`, "Failed to update metadata for lvfs: new signing timestamp was 82 seconds older", which suggests that I haven't completely figured out the problem with the timestamps.  I'll set the PR to draft for now and try to reproduce and fix this failure.  Much of the code should still be ready for review.